### PR TITLE
Update LRU cache on item retrieval (hacky)

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -79,6 +79,11 @@ module.exports = function(options) {
 
       if ((item) && ((!item.expire) || (item.expire) && (item.expire >= Date.now()))) {
         response = item.value;
+
+        delete lru[item.lruId];
+        lru[lruId] = key;
+        item.lruId = lruId;
+        lruId++;
       }
       return response;
     },


### PR DESCRIPTION
I've submitted this pull request to "solve" issue #2 for now, but we should have a chat about how the cache is structured when you have the time.

Because `lru.shift()` is used during GC, all items in the `cache` object will have mismatched `.lruId` properties as soon as a single item is deleted from the cache. This will result in items being randomly exempt from the LRU check (this should be considered a memory leak).

Also, `delete array[index]` is used in a few places in the project. This won't actually remove the element at `index`, but rather set it to `undefined`. This will lead to strange behaviour when clearing the LRU. During LRU clears, `lru.shift()` will fetch these, now undefined, elements which point to items which at this point have already been removed from the cache.

Finally, when overwriting an existing key, the previous LRU entry isn't removed or invalidated, causing the new item to now have two (or more) items in the LRU queue. This will again lead to inconsistent behaviour when clearing the LRU.

I stumbled upon a few other issues, but they are primarily performance related.
